### PR TITLE
revert deepsource changes

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,12 +1,23 @@
 version = 1
 
+test_patterns = ["app/javascript/mastodon/**/__tests__/**"]
+
+exclude_patterns = [
+    "db/migrate/**",
+    "db/post_migrate/**"
+]
+
+[[analyzers]]
+name = "ruby"
+enabled = true
+
 [[analyzers]]
 name = "javascript"
 enabled = true
 
   [analyzers.meta]
-  plugins = ["react"]
-
-[[analyzers]]
-name = "ruby"
-enabled = true
+  environment = [
+    "browser",
+    "jest",
+    "nodejs"
+  ]


### PR DESCRIPTION
After transferring my repo to c4social, I had to reconfigure deepsource. In that process, they pushed a new toml file to the c4social c4 branch. This reverts that back to the one that matched how upstream applies deepsource