### PR TITLE
Update .codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -14,6 +14,8 @@ checks:
     enabled: false
   nested-control-flow:
     enabled: false
+  parameter-lists:
+    enabled: false
   return-statements:
     enabled: false
   similar-code:


### PR DESCRIPTION
Problem: CodeClimate doesn't like parameter lists longer than five parameters which forces creating data structures where they may not be needed. Motivated by blocking #175